### PR TITLE
cleanup: remove mention of navigation on website

### DIFF
--- a/src/lib/constants/faq.svelte
+++ b/src/lib/constants/faq.svelte
@@ -300,8 +300,7 @@
               subscription).
             </p>
             <p>
-              connect provides other features such as battery voltage, snapshot, and
-              navigation guidance.
+              connect provides other features such as battery voltage, and remote snapshots.
             </p>
           `
         }, {

--- a/src/lib/constants/faq.svelte
+++ b/src/lib/constants/faq.svelte
@@ -300,7 +300,7 @@
               subscription).
             </p>
             <p>
-              connect provides other features such as battery voltage, and remote snapshots.
+              connect provides other features such as battery voltage and remote snapshots.
             </p>
           `
         }, {

--- a/src/routes/connect/+page.svelte
+++ b/src/routes/connect/+page.svelte
@@ -51,7 +51,7 @@
     <span class="badge-prefix muted">connect</span><Badge style="dark" display="inline">subscription</Badge>
     <Grid rowGap="0" templateColumns="1.25fr 1fr">
       <h1>Access premium features with connect subscription.</h1>
-      <p>Get a connect subscription for navigation, live car tracking, and cloud storage of your drives for 1 year.</p>
+      <p>Get a connect subscription for live car tracking, and cloud storage of your drives for 1 year.</p>
     </Grid>
 
     <div id="features-table">

--- a/src/routes/connect/+page.svelte
+++ b/src/routes/connect/+page.svelte
@@ -51,7 +51,7 @@
     <span class="badge-prefix muted">connect</span><Badge style="dark" display="inline">subscription</Badge>
     <Grid rowGap="0" templateColumns="1.25fr 1fr">
       <h1>Access premium features with connect subscription.</h1>
-      <p>Get a connect subscription for live car tracking, and cloud storage of your drives for 1 year.</p>
+      <p>Get a connect subscription for live car tracking and cloud storage of your drives for 1 year.</p>
     </Grid>
 
     <div id="features-table">

--- a/src/routes/shop/comma-3x/+page.svelte
+++ b/src/routes/shop/comma-3x/+page.svelte
@@ -101,7 +101,7 @@
         <p>
           comma 3X includes one free month of comma prime.
           To claim your free prime trial, log into <a href="https://connect.comma.ai/" target="_blank" class="highlight">comma connect</a>.
-          Once paired, you can see your recorded drives, set navigation destinations, and more.
+          Once paired, you can see your recorded drives, SSH into your device from anywhere, and more.
         </p>
       </div>
     </Grid>

--- a/src/routes/shop/products/comma-prime-sim.svelte
+++ b/src/routes/shop/products/comma-prime-sim.svelte
@@ -31,16 +31,8 @@
   <div slot="description">
     <strong>Description</strong>
     <p>
-      Give your comma 3/3X a SIM card and internet connectivity. The comma prime SIM card (plus a <a
-        href="/connect">comma prime subscription</a
-      >) gives you the ability to:
+      This is a replacement for the SIM that ships with your comma 3/3X to support <a href="/connect">comma prime</a>.
     </p>
-    <ul>
-      <li>Access your device remotely from anywhere via SSH</li>
-      <li>See your vehicles last location in comma connect</li>
-      <li>Upload drive summaries in real time</li>
-      <li>Your drives are stored for 1 year (only 3 days without prime)</li>
-    </ul>
     <p>
       See how to replace the SIM card in a comma 3/3X
       <a href="/support#how-do-you-replace-the-sim-card-in-a-comma-3x" target="_blank">here</a>.

--- a/src/routes/shop/products/comma-prime-sim.svelte
+++ b/src/routes/shop/products/comma-prime-sim.svelte
@@ -31,7 +31,7 @@
   <div slot="description">
     <strong>Description</strong>
     <p>
-      This is a replacement for the SIM that ships with your comma 3/3X to support <a href="/connect">comma prime</a>.
+      This is a replacement for the SIM that ships with the comma 3X to support <a href="/connect">comma prime</a>.
     </p>
     <p>
       See how to replace the SIM card in a comma 3/3X

--- a/src/routes/shop/products/comma-prime-sim.svelte
+++ b/src/routes/shop/products/comma-prime-sim.svelte
@@ -40,7 +40,6 @@
       <li>See your vehicles last location in comma connect</li>
       <li>Upload drive summaries in real time</li>
       <li>Your drives are stored for 1 year (only 3 days without prime)</li>
-      <li>Turn-by-turn navigation</li>
     </ul>
     <p>
       See how to replace the SIM card in a comma 3/3X

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -46,7 +46,7 @@
         <p>
           openpilot does not make your vehicle “autonomous” or capable of operation without the active monitoring of a licensed driver.
           It is designed to assist a licensed driver.
-          A licensed driver must pay attention to the road, remain aware of navigation at all times, and be prepared to take immediate action.
+          A licensed driver must pay attention to the road and be prepared to take immediate action.
           Failure to do so can cause damage, injury, or death.
         </p>
 

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -46,7 +46,7 @@
         <p>
           openpilot does not make your vehicle “autonomous” or capable of operation without the active monitoring of a licensed driver.
           It is designed to assist a licensed driver.
-           A licensed driver must pay attention to the road, remain aware of navigation at all times, and be prepared to take immediate action.
+          A licensed driver must pay attention to the road, remain aware of navigation at all times, and be prepared to take immediate action.
           Failure to do so can cause damage, injury, or death.
         </p>
 

--- a/src/routes/terms/+page.svelte
+++ b/src/routes/terms/+page.svelte
@@ -46,7 +46,7 @@
         <p>
           openpilot does not make your vehicle “autonomous” or capable of operation without the active monitoring of a licensed driver.
           It is designed to assist a licensed driver.
-          A licensed driver must pay attention to the road and be prepared to take immediate action.
+           A licensed driver must pay attention to the road, remain aware of navigation at all times, and be prepared to take immediate action.
           Failure to do so can cause damage, injury, or death.
         </p>
 


### PR DESCRIPTION
we removed navigation a few months ago i believe, yet we still mention this on the website. Although we intend to bring it up we should just remove it until it's added back to openpilot + connect