### PR TITLE
CI: cleanup build workflow

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: build
+name: Build
 
 on:
   push:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: deploy production
+name: build
 
 on:
   push:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -18,6 +18,7 @@ permissions:
 
 jobs:
   build:
+    name: Build site
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,5 @@
 name: deploy production
+
 on:
   push:
     branches:
@@ -16,13 +17,14 @@ permissions:
   pull-requests: write
 
 jobs:
-  production:
+  build:
     runs-on: ubuntu-latest
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
     steps:
       - uses: actions/checkout@v4
       - uses: oven-sh/setup-bun@v2
+
       - run: bun install --frozen-lockfile
+
       - name: Cache imagetools directory
         uses: actions/cache@v4
         with:
@@ -30,34 +32,23 @@ jobs:
           key: imagetools-${{ hashFiles('**/*.png', '**/*.jpg', '**/*.jpeg', '**/*.gif') }}
           restore-keys: |
             imagetools-
+
       - run: bun run build
         env:
           VITE_SHOPIFY_STOREFRONT_API_TOKEN: ${{ secrets.VITE_SHOPIFY_STOREFRONT_API_TOKEN }}
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+
+      - name: Deploy to prod
+        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_COMMA_WEB }}
           channelId: live
           projectId: comma-web
 
-  preview:
-    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: oven-sh/setup-bun@v2
-      - run: bun install --frozen-lockfile
-      - name: Cache imagetools directory
-        uses: actions/cache@v4
-        with:
-          path: ./node_modules/.cache/imagetools
-          key: imagetools-${{ hashFiles('**/*.png', '**/*.jpg', '**/*.jpeg', '**/*.gif') }}
-          restore-keys: |
-            imagetools-
-      - run: bun run build
-        env:
-          VITE_SHOPIFY_STOREFRONT_API_TOKEN: ${{ secrets.VITE_SHOPIFY_STOREFRONT_API_TOKEN }}
-      - uses: FirebaseExtended/action-hosting-deploy@v0
+      - name: Deploy preview
+        if: github.event.pull_request.head.repo.full_name == github.repository
+        uses: FirebaseExtended/action-hosting-deploy@v0
         with:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_COMMA_WEB }}


### PR DESCRIPTION
De-duplicate build steps by merging prod/preview into one job.

Next step is to support external pull requests by moving the preview deployment to a [separate workflow](https://securitylab.github.com/resources/github-actions-preventing-pwn-requests/).