### PR TITLE
CI: preview workflow on build workflow completed

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,6 +38,14 @@ jobs:
         env:
           VITE_SHOPIFY_STOREFRONT_API_TOKEN: ${{ secrets.VITE_SHOPIFY_STOREFRONT_API_TOKEN }}
 
+      - name: Upload built project
+        uses: actions/upload-artifact@v4
+        with:
+          path: ./build
+          overwrite: true
+          retention-days: 1
+          name: build-artifacts-${{ github.run_id }}
+
       - name: Deploy to prod
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
         uses: FirebaseExtended/action-hosting-deploy@v0
@@ -45,12 +53,4 @@ jobs:
           repoToken: ${{ secrets.GITHUB_TOKEN }}
           firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_COMMA_WEB }}
           channelId: live
-          projectId: comma-web
-
-      - name: Deploy preview
-        if: github.event.pull_request.head.repo.full_name == github.repository
-        uses: FirebaseExtended/action-hosting-deploy@v0
-        with:
-          repoToken: ${{ secrets.GITHUB_TOKEN }}
-          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_COMMA_WEB }}
           projectId: comma-web

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -1,0 +1,131 @@
+name: Preview
+
+on:
+  workflow_run:
+    workflows: ["Build"]
+    types: ["completed"]
+
+permissions:
+  checks: write
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.workflow }}
+  cancel-in-progress: true
+
+jobs:
+  pr:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    name: Find PR number
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    outputs:
+      number: ${{ steps.pr.outputs.number }}
+    steps:
+      # use `gr pr view` to get the PR number
+      # https://github.com/orgs/community/discussions/25220#discussioncomment-11285971
+      - name: Find PR number
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_TARGET_REPO: ${{ github.repository }}
+          PR_BRANCH: |-
+            ${{
+              (github.event.workflow_run.head_repository.owner.login != github.event.workflow_run.repository.owner.login)
+                && format('{0}:{1}', github.event.workflow_run.head_repository.owner.login, github.event.workflow_run.head_branch)
+                || github.event.workflow_run.head_branch
+            }}
+        run: |
+          gh pr view --repo "${PR_TARGET_REPO}" "${PR_BRANCH}" \
+            --json 'number' \
+            --jq '"number=\(.number)"' \
+            >> $GITHUB_OUTPUT
+
+      - run: |
+          echo "PR number: ${{ steps.pr.outputs.number }}"
+
+  preview:
+    if: github.event.workflow_run.conclusion == 'success' && github.event.workflow_run.event == 'pull_request'
+    needs: pr
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    outputs:
+      check_id: ${{ steps.check.outputs.result }}
+    steps:
+      - name: Create PR check
+        uses: actions/github-script@v7
+        id: check
+        with:
+          script: |
+            const response = await github.rest.checks.create({
+              name: 'preview',
+              head_sha: '${{ github.event.workflow_run.head_sha }}',
+              status: 'in_progress',
+              output: {
+                title: 'Preview deployment',
+                summary: 'In Progress',
+              },
+              owner: 'commaai',
+              repo: '${{ github.event.repository.name }}',
+            })
+            return response.data.id
+
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: build-artifacts-${{ github.event.workflow_run.id }}
+          path: ./build
+          run-id: ${{ github.event.workflow_run.id }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Deploy preview
+        uses: FirebaseExtended/action-hosting-deploy@v0
+        with:
+          repoToken: ${{ secrets.GITHUB_TOKEN }}
+          firebaseServiceAccount: ${{ secrets.FIREBASE_SERVICE_ACCOUNT_COMMA_WEB }}
+          projectId: comma-web
+          channelId: pr${{ needs.pr.outputs.number }}
+
+      - name: Comment URL on PR
+        uses: thollander/actions-comment-pull-request@v3
+        with:
+          message: |
+            <!-- _(run_id **${{ github.run_id }}**)_ -->
+
+            # deployed preview: https://comma-web--pr${{ needs.pr.outputs.number }}.web.app
+
+            Welcome! Make sure to:
+            * read the contributing guidelines
+            * mark your PR as a draft until it's ready to review
+            * post the preview on [Discord](https://discord.comma.ai); feedback from users will speedup the PR review
+          comment-tag: run_id
+          pr-number: ${{ needs.pr.outputs.number }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+  update_pr_check:
+    if: always() && github.event.workflow_run.event == 'pull_request'
+    needs: preview
+    runs-on: ubuntu-latest
+    timeout-minutes: 1
+    steps:
+      - name: Update PR check
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.checks.update({
+              check_run_id: ${{ needs.preview.outputs.check_id }},
+              name: 'preview',
+              head_sha: '${{ github.event.workflow_run.head_sha }}',
+              status: 'completed',
+              conclusion: '${{ needs.preview.result }}',
+              output: {
+                title: 'Preview deployment',
+                summary: 'Result: ${{ needs.preview.result }}',
+              },
+              owner: 'commaai',
+              repo: '${{ github.event.repository.name }}',
+            })


### PR DESCRIPTION
Upload build artifacts in build workflow and deploy to Firebase in preview workflow

Most of this is based on the setup in new-connect, so maybe we could create a couple of standalone actions to reduce duplication