### PR TITLE
Refactor Shopify API config and update version to 2025-01

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-VITE_SHOPIFY_API_VERSION=2024-07 # Update this as needed once any breaking changes are resolved
+VITE_SHOPIFY_API_VERSION=2025-01 # Update this as needed once any breaking changes are resolved
 VITE_SHOPIFY_STORE_URL=comma-dev.myshopify.com # e.g. store.myshopify.com (without protocol)
 VITE_SHOPIFY_STOREFRONT_API_TOKEN=ee9baaeb9964250671e3abe92cef70e6 

--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
-VITE_SHOPIFY_STOREFRONT_API_ENDPOINT=https://comma-dev.myshopify.com/api/2024-07/graphql.json
-VITE_SHOPIFY_STOREFRONT_API_TOKEN=ee9baaeb9964250671e3abe92cef70e6
+VITE_SHOPIFY_API_VERSION=2024-07 # Update this as needed once any breaking changes are resolved
+VITE_SHOPIFY_STORE_URL=comma-dev.myshopify.com # e.g. store.myshopify.com (without protocol)
+VITE_SHOPIFY_STOREFRONT_API_TOKEN=ee9baaeb9964250671e3abe92cef70e6 

--- a/src/lib/utils/shopify.js
+++ b/src/lib/utils/shopify.js
@@ -1,6 +1,10 @@
 import { get } from 'svelte/store';
 import { cartId, cartCreatedAt, checkoutUrl, cartTotalQuantity } from '../../store';
 
+// GraphQL fragments for error handling
+const USER_ERRORS_GQL = `userErrors { code field message }`;
+const WARNINGS_GQL = `warnings { code message target }`;
+
 export async function shopifyFetch({ query, variables }) {
   const apiToken = import.meta.env.VITE_SHOPIFY_STOREFRONT_API_TOKEN;
   const storeUrl = import.meta.env.VITE_SHOPIFY_STORE_URL;
@@ -188,10 +192,8 @@ export async function updateCart({ cartId, lineId, variantId, quantity }) {
     query: /* graphql */ `
       mutation cartLinesUpdate($cartId: ID!, $lines: [CartLineUpdateInput!]!) {
         cartLinesUpdate(cartId: $cartId, lines: $lines) {
-          userErrors {
-            field
-            message
-          }
+          ${USER_ERRORS_GQL}
+          ${WARNINGS_GQL}
         }
       }
     `,
@@ -231,10 +233,8 @@ export async function addToCart({ cartId, variantId, additionalProductIds = [], 
               }
             }
           }
-          userErrors {
-            field
-            message
-          }
+          ${USER_ERRORS_GQL}
+          ${WARNINGS_GQL}
         }
       }
     `,
@@ -251,8 +251,11 @@ export async function addToCart({ cartId, variantId, additionalProductIds = [], 
     }
   });
 
-  if (cartLinesResponse.errors || cartLinesResponse.data?.cartLinesAdd?.userErrors?.length) {
-    console.error("Error adding items to cart:", cartLinesResponse.errors || cartLinesResponse.data.cartLinesAdd.userErrors);
+  const { errors, data } = cartLinesResponse;
+  const { cartLinesAdd } = data || {};
+  const cartLinesErrors = errors || cartLinesAdd?.userErrors || cartLinesAdd?.warnings;
+  if (errors || cartLinesErrors?.length) {
+    console.error("Error adding items to cart:", cartLinesErrors);
     return cartLinesResponse;
   }
 
@@ -266,10 +269,8 @@ export async function addToCart({ cartId, variantId, additionalProductIds = [], 
               id
               note
             }
-            userErrors {
-              field
-              message
-            }
+            ${USER_ERRORS_GQL}
+            ${WARNINGS_GQL}
           }
         }
       `,
@@ -279,8 +280,11 @@ export async function addToCart({ cartId, variantId, additionalProductIds = [], 
       },
     });
 
-    if (cartNoteResponse.errors || cartNoteResponse.data?.cartNoteUpdate?.userErrors?.length) {
-      console.error("Error updating cart note:", cartNoteResponse.errors || cartNoteResponse.data.cartNoteUpdate.userErrors);
+    const { errors, data } = cartNoteResponse;
+    const { cartNoteUpdate } = data || {};
+    const cartNoteErrors = errors || cartNoteUpdate?.userErrors || cartNoteUpdate?.warnings;
+    if (errors || cartNoteErrors?.length) {
+      console.error("Error updating cart note:", cartNoteErrors);
     }
 
     return {

--- a/src/lib/utils/shopify.js
+++ b/src/lib/utils/shopify.js
@@ -2,15 +2,23 @@ import { get } from 'svelte/store';
 import { cartId, cartCreatedAt, checkoutUrl, cartTotalQuantity } from '../../store';
 
 export async function shopifyFetch({ query, variables }) {
-  const endpoint = import.meta.env.VITE_SHOPIFY_STOREFRONT_API_ENDPOINT;
-  const token = import.meta.env.VITE_SHOPIFY_STOREFRONT_API_TOKEN;
+  const apiToken = import.meta.env.VITE_SHOPIFY_STOREFRONT_API_TOKEN;
+  const storeUrl = import.meta.env.VITE_SHOPIFY_STORE_URL;
+  const apiVersion = import.meta.env.VITE_SHOPIFY_API_VERSION || 'unstable';
+  const endpoint = `https://${storeUrl}/api/${apiVersion}/graphql.json`;
+
+  if (apiVersion === 'unstable') {
+    console.warn(
+      'Using an unstable Shopify API version. Please ensure the API version is specified in your .env file.'
+    );
+  }
 
   try {
     const result = await fetch(endpoint, {
       method: 'POST',
       headers: {
         'Content-Type': 'application/json',
-        'X-Shopify-Storefront-Access-Token': token
+        'X-Shopify-Storefront-Access-Token': apiToken
       },
       body: { query, variables } && JSON.stringify({ query, variables })
     });
@@ -20,7 +28,7 @@ export async function shopifyFetch({ query, variables }) {
       body: await result.json()
     };
   } catch (error) {
-    console.error('Error:', error);
+    console.error('Error making Shopify Storefront API request:', error);
     return {
       status: 500,
       error: 'Error receiving data'


### PR DESCRIPTION
This updates the Shopify Storefront API requests to use the latest stable version `2025-01` instead of `2024-07`.

The [`2024-10`](https://shopify.dev/docs/api/release-notes/2024-10#storefront-api-changes) version introduced a potentially breaking change where some errors were moved from `userErrors` into a new `warnings` field. [Read more.](https://shopify.dev/docs/storefronts/headless/building-with-the-storefront-api/cart/cart-warnings) So this adds support for handling those fields as well where `userErrors` was handled before, with some refactoring for maintainability.

It also refactors the `.env` variables for the Shopify API requests to replace the `VITE_SHOPIFY_STOREFRONT_API_ENDPOINT` variable with two new ones:
- `VITE_SHOPIFY_API_VERSION` (so it's easier to update in the future without replacing the whole URL)
- `VITE_SHOPIFY_STORE_URL` (e.g. "comma-dev.myshopify.com")