### PR TITLE
Fix non-accent button hover

### DIFF
--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -35,11 +35,28 @@
     transition: all 0.2s;
 
     @media (hover: hover) and (pointer: fine) {
-      &:hover:not(.disabled) {
+      &.primary:hover:not(.disabled) {
+        opacity: 0.75;
+      }
+
+      &.secondary:hover:not(.disabled) {
+        opacity: 0.8;
+      }
+
+      &.accent:hover:not(.disabled) {
         background-color: var(--color-accent-hover);
       }
     }
-    &:active:not(.disabled) {
+
+    &.primary:active:not(.disabled) {
+      opacity: 0.75;
+    }
+
+    &.secondary:active:not(.disabled) {
+      opacity: 0.8;
+    }
+
+    &.accent:active:not(.disabled) {
       background-color: var(--color-accent-hover);
     }
   }

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -35,11 +35,30 @@
     transition: all 0.2s;
 
     @media (hover: hover) and (pointer: fine) {
-      &:hover:not(.disabled) {
+      &.primary:hover {
+        opacity: 0.75;
+      }
+
+      &.secondary:hover {
+        opacity: 0.8;
+      }
+
+      &.accent:hover {
+        color: black;
         background-color: var(--color-accent-hover);
       }
     }
-    &:active:not(.disabled) {
+
+    &.primary:active {
+      opacity: 0.75;
+    }
+
+    &.secondary:active {
+      opacity: 0.8;
+    }
+
+    &.accent:active {
+      color: black;
       background-color: var(--color-accent-hover);
     }
   }

--- a/src/lib/components/Button.svelte
+++ b/src/lib/components/Button.svelte
@@ -35,30 +35,11 @@
     transition: all 0.2s;
 
     @media (hover: hover) and (pointer: fine) {
-      &.primary:hover {
-        opacity: 0.75;
-      }
-
-      &.secondary:hover {
-        opacity: 0.8;
-      }
-
-      &.accent:hover {
-        color: black;
+      &:hover:not(.disabled) {
         background-color: var(--color-accent-hover);
       }
     }
-
-    &.primary:active {
-      opacity: 0.75;
-    }
-
-    &.secondary:active {
-      opacity: 0.8;
-    }
-
-    &.accent:active {
-      color: black;
+    &:active:not(.disabled) {
       background-color: var(--color-accent-hover);
     }
   }


### PR DESCRIPTION
Currently, the only non-accented Button component being used is the "Go back" button in the "Modal", which is being used to show the following warning:
![2025-02-28_22-34](https://github.com/user-attachments/assets/ea3049bd-795c-4fc5-b70a-808200d1933e)

But the only hover styles set are for the "accent" button, so hovering looks like this:
![2025-02-28_22-34_1](https://github.com/user-attachments/assets/27a7e122-4be7-4342-8a33-34bee6191026)

This adds the proper hover effects, copied from LinkButton, to use opacity for the hover on "primary" and "secondary" buttons (when not disabled). So now it looks like this when hovering:
![2025-03-01_13-28](https://github.com/user-attachments/assets/0372af4b-eaa0-4d22-9ecc-e2fc3295631c)
