### PR TITLE
Increase pagination limits for cart lines and product variants to 250

### DIFF
--- a/src/lib/utils/shopify.js
+++ b/src/lib/utils/shopify.js
@@ -76,7 +76,7 @@ export async function _loadCart() {
               currencyCode
             }
           }
-          lines(first: 100) {
+          lines(first: 250) {
             edges {
               node {
                 id
@@ -137,7 +137,7 @@ export async function getProduct(id) {
               currencyCode
             }
           }
-          variants(first: 100) {
+          variants(first: 250) {
             nodes {
               id
               title
@@ -217,7 +217,7 @@ export async function addToCart({ cartId, variantId, additionalProductIds = [], 
         cartLinesAdd(cartId: $cartId, lines: $lines) {
           cart {
             id
-            lines(first: 100) {
+            lines(first: 250) {
               edges {
                 node {
                   id


### PR DESCRIPTION
Even though it's very unlikely there would be more than 100 lines in the cart, or more than 100 harness variants (currently there's around 40, I think), we might as well maximize the limit just in case. Shopify supports up to 250 connections in a single GraphQL request (before pagination would be required), so we might as well increase it since 100 seemed kind of arbitrary.

Partially pulled out of #25 per request