### PR TITLE
Refactor harnesses to support only showing vehicle (or generic) harnesses, and include make

### DIFF
--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -5,7 +5,7 @@
 
   import { tick } from 'svelte';
   import { clickOutside } from '$lib/utils/clickOutside';
-  import { harnesses } from '$lib/utils/harnesses';
+  import { allHarnesses, vehicleHarnesses, genericHarnesses } from '$lib/utils/harnesses';
 
   import NoteCard from '$lib/components/NoteCard.svelte';
   import DropdownItem from './HarnessDropdownItem.svelte';
@@ -18,9 +18,13 @@
 
   export let label = "Select vehicle";
   export let accessoryLabel = null;
+  export let showVehicleHarnesses = true; // If true, includes the harnesses by each vehicle model
+  export let showGenericHarnesses = true; // If true, includes the generic/developer harnesses
 
   let selection;
 
+  // Load harnesses based on the options
+  $: harnesses = showVehicleHarnesses && showGenericHarnesses ? allHarnesses : showVehicleHarnesses ? vehicleHarnesses : genericHarnesses;
   $: browser && $harnesses.length > 0, setInitialSelection();
   $: if (selection) {
     onChange(selection);

--- a/src/lib/utils/harnesses.js
+++ b/src/lib/utils/harnesses.js
@@ -24,8 +24,8 @@ async function initializeHarnesses() {
 
   const harnessInfo = await fetchHarnessVariants();
 
-  let harnessList = Object.values(Vehicles).flatMap(make => {
-    return make.map(model => {
+  let harnessList = Object.entries(Vehicles).flatMap(([make, models]) => {
+    return models.map(model => {
       if (model.name === 'comma body') return false;
       const harness = CarHarnesses.find(harness => harness.title === model.harness_connector);
       if (!harness) {
@@ -34,6 +34,7 @@ async function initializeHarnesses() {
       return {
         ...harnessInfo[harness.id],
         ...harness,
+        make,
         car: model.name,
         package: model.package,
         angledMount: model.angled_mount,

--- a/src/lib/utils/harnesses.js
+++ b/src/lib/utils/harnesses.js
@@ -16,15 +16,18 @@ async function fetchHarnessVariants() {
   }, {});
 }
 
-const harnesses = writable([]);
 let initialized = false;
+const vehicleHarnesses = writable([]); // List of vehicle model harnesses, excluding developer and generic make harnesses
+const genericHarnesses = writable([]); // List of developer and generic make harnesses
+const allHarnesses = writable([]); // List of all vehicle model harnesses, including developer and generic make harnesses
 
 async function initializeHarnesses() {
   if (initialized) return;
 
   const harnessInfo = await fetchHarnessVariants();
 
-  let harnessList = Object.entries(Vehicles).flatMap(([make, models]) => {
+  // Add harnesses for vehicles
+  let vehiclesHarnessList = Object.entries(Vehicles).flatMap(([make, models]) => {
     return models.map(model => {
       if (model.name === 'comma body') return false;
       const harness = CarHarnesses.find(harness => harness.title === model.harness_connector);
@@ -42,21 +45,26 @@ async function initializeHarnesses() {
       };
     }).filter(Boolean);
   });
+  vehicleHarnesses.set(vehiclesHarnessList);
 
-  // add developer harnesses
-  harnessList.push(...CarHarnesses.map(harness => {
+  // Add developer and generic make harnesses
+  let genericHarnessList = CarHarnesses.map(harness => {
     return {
       ...harnessInfo[harness.id],
       car: harness.title,
       id: harness.id,
       backordered: harness.backordered,
     };
-  }));
+  });
+  genericHarnesses.set(genericHarnessList);
 
-  harnesses.set(harnessList);
+  // Combine the two lists
+  let allHarnessList = vehiclesHarnessList.concat(genericHarnessList);
+  allHarnesses.set(allHarnessList);
+
   initialized = true;
 }
 
 initializeHarnesses();
 
-export { harnesses };
+export { allHarnesses, vehicleHarnesses, genericHarnesses };


### PR DESCRIPTION
The default behavior is to show both vehicle-specific and generic harnesses. But in #25 it doesn't make sense to include generic harnesses in the vehicle selector for the custom setup notes, so this makes it so we can more easily control which ones to show.

Also adds the "make" property to the harness for vehicle-specific harnesses, which is also used for #25.

I was asked to make this a separate PR.