### PR TITLE
Make clear button close harness selector when no search input and clear query params

### DIFF
--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -28,10 +28,12 @@
   }
 
   function updateQueryParams(selectedHarness) {
-    const [make, ...model] = selectedHarness.car.split(' ');
     const searchParams = new URLSearchParams();
-    searchParams.set("make", encodeURIComponent(make));
-    if (model.length > 0) searchParams.set("model", encodeURIComponent(model.join(' ')));
+    if (selectedHarness) {
+      const [make, ...model] = selectedHarness.car.split(' ') || [];
+      if (make) searchParams.set("make", encodeURIComponent(make));
+      if (model.length > 0) searchParams.set("model", encodeURIComponent(model.join(' ')));
+    }
     goto(`?${searchParams.toString()}`, { keepfocus: true, replaceState: true, noScroll: true });
   }
 
@@ -60,10 +62,10 @@
     inputValue = "";
     handleInput();
     inputRef?.focus();
-
-     // clear harness selection
-     selection = null;
-     onChange(null);
+    // clear harness selection
+    selection = null;
+    onChange(null);
+    updateQueryParams(null);
   }
 
   /* Dropdown Options */

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -28,11 +28,14 @@
   }
 
   function updateQueryParams(selectedHarness) {
-    const searchParams = new URLSearchParams();
+    const searchParams = new URLSearchParams(window.location.search);
     if (selectedHarness) {
       const [make, ...model] = selectedHarness.car.split(' ') || [];
       if (make) searchParams.set("make", encodeURIComponent(make));
       if (model.length > 0) searchParams.set("model", encodeURIComponent(model.join(' ')));
+    } else {
+      searchParams.delete("make");
+      searchParams.delete("model");
     }
     goto(`?${searchParams.toString()}`, { keepfocus: true, replaceState: true, noScroll: true });
   }

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -65,17 +65,25 @@
 
   const handleClear = () => {
     // clear search input
-    const clearedInput = inputValue !== "";
-    inputValue = "";
-    handleInput();
-    inputRef?.focus();
-    // clear harness selection
-    selection = null;
-    onChange(null);
-    updateQueryParams(null);
-    // close the dropdown if it's open and we didn't clear the search input
-    if (menuOpen && !clearedInput) {
-      menuOpen = false;
+    let clearedInput = false;
+    if (inputValue) {
+      inputValue = "";
+      clearedInput = true;
+      handleInput();
+      inputRef?.focus();
+    }
+    // clear harness selection and close if we weren't clearing the search input
+    if (!clearedInput) {
+      // clear harness selection
+      if (selection) {
+        selection = null;
+        onChange(null);
+        updateQueryParams(null); // NOTE: Doing this causes a soft reload which removes the focus from the input
+      }
+      // close the dropdown if it's open
+      if (menuOpen) {
+        menuOpen = false;
+      }
     }
   }
 

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -29,12 +29,15 @@
 
   function updateQueryParams(selectedHarness) {
     const searchParams = $page.url.searchParams;
-    if (selectedHarness) {
-      const [make, ...model] = selectedHarness.car.split(' ') || [];
-      if (make) searchParams.set("make", encodeURIComponent(make));
-      if (model.length > 0) searchParams.set("model", encodeURIComponent(model.join(' ')));
+    const [make, ...model] = selectedHarness?.car?.split(' ') || [];
+    if (make) {
+      searchParams.set("make", encodeURIComponent(make));
     } else {
       searchParams.delete("make");
+    }
+    if (model?.length > 0) {
+      searchParams.set("model", encodeURIComponent(model.join(' ')));
+    } else {
       searchParams.delete("model");
     }
     goto(`?${searchParams.toString()}`, { keepfocus: true, replaceState: true, noScroll: true });

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -62,6 +62,7 @@
 
   const handleClear = () => {
     // clear search input
+    const clearedInput = inputValue !== "";
     inputValue = "";
     handleInput();
     inputRef?.focus();
@@ -69,8 +70,10 @@
     selection = null;
     onChange(null);
     updateQueryParams(null);
-    // also close the dropdown if it's open
-    menuOpen = false;
+    // close the dropdown if it's open and we didn't clear the search input
+    if (menuOpen && !clearedInput) {
+      menuOpen = false;
+    }
   }
 
   /* Dropdown Options */

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -69,6 +69,8 @@
     selection = null;
     onChange(null);
     updateQueryParams(null);
+    // also close the dropdown if it's open
+    menuOpen = false;
   }
 
   /* Dropdown Options */

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -28,7 +28,7 @@
   }
 
   function updateQueryParams(selectedHarness) {
-    const searchParams = new URLSearchParams(window.location.search);
+    const searchParams = $page.url.searchParams;
     if (selectedHarness) {
       const [make, ...model] = selectedHarness.car.split(' ') || [];
       if (make) searchParams.set("make", encodeURIComponent(make));


### PR DESCRIPTION
While working on #25, I kept clicking the clear (X) button to close the selector and it wasn't doing anything because it's only designed to clear the search input or clear the current selection. But if there's no selection and no search input, it doesn't do anything which is very unintuitive.

It also clears the make/model query params when the selection is cleared, and ensures they are always updated correctly.

![image](https://github.com/user-attachments/assets/e8049af6-091e-494d-98e7-fa81a3bb5741)

This was implemented in #25, but I decided to pull it out as a separate PR for better readability.
