### PR TITLE
fix: don't clear harness selection on init

### DIFF
--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -22,13 +22,16 @@
   export let showGenericHarnesses = true; // If true, includes the generic/developer harnesses
 
   let selection = null
+  let initialized = false;
 
   // Load harnesses based on the options
   $: harnesses = showVehicleHarnesses && showGenericHarnesses ? allHarnesses : showVehicleHarnesses ? vehicleHarnesses : genericHarnesses;
   $: browser && $harnesses.length > 0, setInitialSelection();
-  $: {
+  $: if (initialized) {
     onChange(selection);
     updateQueryParams(selection);
+  } else {
+    initialized = true;
   }
 
   function updateQueryParams(selectedHarness) {


### PR DESCRIPTION
I hit this bug in #63, where the selected vehicle doesn't persist after refreshing the page.

It seems as though the selection in HarnessSelector is not restored because the harness list isn't fully populated by the time setInitialSelection is called. Then this effect runs while `selection = null` and resets the query params.

Haven't looked at why this doesn't affect the store pages yet.