### PR TITLE
fix: wait for harnesses before selector init

### DIFF
--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -28,7 +28,7 @@
   $: harnesses = showVehicleHarnesses && showGenericHarnesses ? allHarnesses : showVehicleHarnesses ? vehicleHarnesses : genericHarnesses;
 
   // When harnesses are ready, set the initial selection
-  $: if (browser && $harnessesReady && $harnesses.length > 0 && !isSelectionInitialized) {
+  $: if (browser && $harnessesReady && !isSelectionInitialized) {
     setInitialSelection();
     isSelectionInitialized = true;
   }

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -40,15 +40,15 @@
   }
 
   function updateQueryParams(selectedHarness) {
-    // https://github.com/sveltejs/kit/discussions/3245#discussioncomment-1931570
-    if (!browser) return;
-
     const searchParams = new URLSearchParams();
     if (selectedHarness) {
       searchParams.set("harness", encodeURIComponent(selectedHarness.car));
     }
 
-    goto(`?${searchParams.toString()}`, { keepfocus: true, replaceState: true, noScroll: true });
+    // https://github.com/sveltejs/kit/discussions/3245#discussioncomment-1931570
+    if (browser) {
+      goto(`?${searchParams.toString()}`, { keepfocus: true, replaceState: true, noScroll: true });
+    }
   }
 
   const setInitialSelection = () => {

--- a/src/lib/utils/harnesses.js
+++ b/src/lib/utils/harnesses.js
@@ -17,6 +17,8 @@ async function fetchHarnessVariants() {
 }
 
 let initialized = false;
+const harnessesReady = writable(false);  // Track initialization status
+
 const vehicleHarnesses = writable([]); // List of vehicle model harnesses, excluding developer and generic make harnesses
 const genericHarnesses = writable([]); // List of developer and generic make harnesses
 const allHarnesses = writable([]); // List of all vehicle model harnesses, including developer and generic make harnesses
@@ -64,8 +66,9 @@ async function initializeHarnesses() {
   allHarnesses.set(allHarnessList);
 
   initialized = true;
+  harnessesReady.set(true);
 }
 
 initializeHarnesses();
 
-export { allHarnesses, vehicleHarnesses, genericHarnesses };
+export { harnessesReady, allHarnesses, vehicleHarnesses, genericHarnesses };


### PR DESCRIPTION
Fixes an issue discovered in https://github.com/commaai/website/pull/63 where the harness selection would not be read from the URL before it is cleared