### PR TITLE
Fix blog post read time

### DIFF
--- a/src/routes/+layout.js
+++ b/src/routes/+layout.js
@@ -9,7 +9,7 @@ export async function load({ fetch }) {
     .then((str) => new XMLParser().parse(str))
     .then((data) => {
       const blogPosts = data.rss.channel.item
-        .map(({ title, guid, pubDate, readTime }) => {
+        .map(({ title, guid, pubDate, "cb:readTime": readTime }) => {
           const date = new Date(pubDate).toLocaleDateString("en-US", {
             year: "numeric",
             month: "long",


### PR DESCRIPTION
<img width="1697" alt="Screenshot 2025-04-30 at 12 29 23 PM" src="https://github.com/user-attachments/assets/9d33bdf6-b70e-4e5b-94d9-89fb8c2ca6b7" />

No clue why, but the RSS feed has readTime namespaced with `cb:`.