### PR TITLE
cleanup: rm imports

### DIFF
--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -8,19 +8,15 @@
 
   import DeviceImage from "$lib/images/device.png";
   import BodyImage from "$lib/images/comma-body.png";
-  import CircuitImage from "$lib/images/circuit.png";
 
   import RecordingsIcon from "$lib/icons/features/recordings.svg?raw";
   import CalendarIcon from "$lib/icons/features/calendar.svg?raw";
   import CurrencyIcon from "$lib/icons/features/currency.svg?raw";
-  import ArrowRightIcon from "$lib/icons/arrow-right.svg?raw";
   import BusinessIcon from "$lib/icons/features/business.svg?raw";
   import ContactIcon from "$lib/icons/features/contact.svg?raw";
   import ImmediateIcon from "$lib/icons/features/immediate.svg?raw";
   import AdaptiveCruiseIcon from "$lib/icons/features/adaptive-cruise.svg?raw";
   import LaneCenteringIcon from "$lib/icons/features/lane-centering.svg?raw";
-
-  import InfoIcon from "$lib/icons/ui/info.svg?raw";
 
   import { THREEX_PRICE, THREEX_AFFIRM_PRICE, THREEX_SALE, THREEX_STRIKETHROUGH_PRICE } from '$lib/constants/prices.js';
   import { vehicleCountText } from '$lib/constants/vehicles.js';


### PR DESCRIPTION
- removed unused imports
- I didn't delete `circuit.png` even though no one is using it because it seems like something that could be used in the future

<img width="1628" height="1218" alt="CleanShot 2025-07-29 at 03 20 03@2x" src="https://github.com/user-attachments/assets/fbb89eeb-859e-4dff-98bb-f99a8e2900f7" />
