### PR TITLE
fix: handle missing product module as 404

### DIFF
--- a/src/routes/shop/[product]/+page.js
+++ b/src/routes/shop/[product]/+page.js
@@ -34,7 +34,7 @@ export async function load({ url }) {
     }
   } catch (e) {
     console.error(`Failed to load product ${productId}:`, e);
-    throw error(response.status, {
+    throw error(404, {
       message: `Product ${productId} not found`,
     })
   }

--- a/src/routes/shop/[product]/+page.js
+++ b/src/routes/shop/[product]/+page.js
@@ -35,7 +35,7 @@ export async function load({ url }) {
   } catch (e) {
     console.error(`Failed to load product ${productId}:`, e);
     throw error(404, {
-      message: `Product ${productId} not found`,
+      message: `Product "${productId}" not found`,
     })
   }
 }


### PR DESCRIPTION
#75: The crash comes from a failed product module import:
https://github.com/commaai/website/blob/13d463aad93da97df6d465b3c7d73cc81cfbdf3d/src/routes/shop/%5Bproduct%5D/%2Bpage.js#L8
It caused `response` to be undefined. Fixed by handling as a 404 error instead.

Now the error looks like:
![404](https://github.com/user-attachments/assets/69d72eed-276c-475b-b318-22b93a0244af)
