### PR TITLE
Rm support label sentence fluff

### DIFF
--- a/src/routes/vehicles/+page.svelte
+++ b/src/routes/vehicles/+page.svelte
@@ -131,9 +131,9 @@
                   <div>
                     <div class="car-detail-tier">{@html car_info.detail_sentence }</div>
                     <div class="cards">
-                      <NoteCard title="Support" icon={CarIcon} style="elevated">
+                      <NoteCard title="Required Package" icon={CarIcon} style="elevated">
                         {#if car_info.package !== 'All'}
-                          openpilot requires the car to come equipped with <b>{car_info.package}</b>.
+                          {car_info.package}
                         {:else}
                           openpilot will work with <b>all packages and trims</b> of this car.
                         {/if}


### PR DESCRIPTION
- users are in the context of the compatibility page already
- having "openpilot requires the car to come equipped with" is verbose and doesn't add much value
- easier to scan
- having just the package also prevents cutting off package names, like the below
- I kept `openpilot will work with <b>all packages and trims</b> of this car.` since it makes clearer that "all" trims and package work vs just a certain one

Go to this page to see changes -> [https://comma-web--pr129-b2yqnfls.web.app/vehicles](https://comma-web--pr129-b2yqnfls.web.app/vehicles)


Related:
PR - https://github.com/commaai/opendbc/pull/2592
incognitojam's comment [here](https://github.com/commaai/opendbc/pull/2592#issuecomment-3140791211)

| Before | After |
|--------|-------|
| ![Before](https://github.com/user-attachments/assets/aa33bbeb-867a-4c8b-ac55-b636be756507) | ![After](https://github.com/user-attachments/assets/09112578-203b-44e5-adf2-efa6bd6f0d2e) |

