### PR TITLE
feat: pre-open FAQ accordion when URL has hash (fixes #142)

### DIFF
--- a/src/lib/components/Faq.svelte
+++ b/src/lib/components/Faq.svelte
@@ -1,7 +1,7 @@
 <script>
-  import { onMount } from "svelte";
-  import Accordion from "./Accordion.svelte";
-  import Grid from "./Grid.svelte";
+  import { onMount } from 'svelte';
+  import Accordion from './Accordion.svelte';
+  import Grid from './Grid.svelte';
 
   export let topic;
   export let title = null;
@@ -9,43 +9,26 @@
 
   const handleExpand = (id) => {
     history.replaceState(null, null, `#${id}`);
-  };
+  }
 
   onMount(() => {
     activehash = window.location.hash.slice(1);
-  });
+  })
 </script>
 
 <div>
-  <div
-    class="header"
-    id={(title ?? topic.title)
-      .toLowerCase()
-      .replace(/[^\w\s]/g, "")
-      .replaceAll(" ", "-")}
-  >
+  <div class="header" id={(title ?? topic.title).toLowerCase().replace(/[^\w\s]/g, '').replaceAll(' ', '-')}>
     <Grid columns={2} alignItems="center" rowGap="0" size="small">
       <h1>{title ?? topic.title}</h1>
       <div class="mobile-first">
-        <img
-          src={topic.image}
-          loading="eager"
-          alt="{title ?? topic.title} banner"
-        />
+        <img src={topic.image} loading="eager" alt="{title ?? topic.title} banner" />
       </div>
     </Grid>
   </div>
   <div class="questions">
     {#each topic.questions as entry}
-      {@const id = entry.question
-        .toLowerCase()
-        .replace(/[^\w\s]/g, "")
-        .replaceAll(" ", "-")}
-      <Accordion
-        checked={id === activehash ? true : false}
-        on:click={() => handleExpand(id)}
-        {id}
-      >
+      {@const id = entry.question.toLowerCase().replace(/[^\w\s]/g, '').replaceAll(' ', '-')}
+      <Accordion checked={id === activehash ? true : false} on:click={() => handleExpand(id)} {id}>
         <div slot="label" class="label">
           <span>{entry.question}</span>
         </div>

--- a/src/lib/components/Faq.svelte
+++ b/src/lib/components/Faq.svelte
@@ -1,39 +1,51 @@
 <script>
-  import { onMount } from 'svelte';
-  import Accordion from './Accordion.svelte';
-  import Grid from './Grid.svelte';
+  import { onMount } from "svelte";
+  import Accordion from "./Accordion.svelte";
+  import Grid from "./Grid.svelte";
 
   export let topic;
   export let title = null;
+  export let activehash = "";
 
   const handleExpand = (id) => {
     history.replaceState(null, null, `#${id}`);
-  }
+  };
 
   onMount(() => {
-    const hash = window.location.hash;
-    if (hash) {
-      const label = document.querySelector(hash);
-      if (label) {
-        label.click();
-      }
-    }
+    activehash = window.location.hash.slice(1);
   });
 </script>
 
 <div>
-  <div class="header" id={(title ?? topic.title).toLowerCase().replace(/[^\w\s]/g, '').replaceAll(' ', '-')}>
+  <div
+    class="header"
+    id={(title ?? topic.title)
+      .toLowerCase()
+      .replace(/[^\w\s]/g, "")
+      .replaceAll(" ", "-")}
+  >
     <Grid columns={2} alignItems="center" rowGap="0" size="small">
       <h1>{title ?? topic.title}</h1>
       <div class="mobile-first">
-        <img src={topic.image} loading="eager" alt="{title ?? topic.title} banner" />
+        <img
+          src={topic.image}
+          loading="eager"
+          alt="{title ?? topic.title} banner"
+        />
       </div>
     </Grid>
   </div>
   <div class="questions">
     {#each topic.questions as entry}
-      {@const id = entry.question.toLowerCase().replace(/[^\w\s]/g, '').replaceAll(' ', '-')}
-      <Accordion on:click={() => handleExpand(id)} {id}>
+      {@const id = entry.question
+        .toLowerCase()
+        .replace(/[^\w\s]/g, "")
+        .replaceAll(" ", "-")}
+      <Accordion
+        checked={id === activehash ? true : false}
+        on:click={() => handleExpand(id)}
+        {id}
+      >
         <div slot="label" class="label">
           <span>{entry.question}</span>
         </div>


### PR DESCRIPTION
### Before


https://github.com/user-attachments/assets/5d9aabe8-f127-49e2-b397-874cac06eb8f


### After

https://github.com/user-attachments/assets/6debfc28-9f42-4b7f-8850-834c17eb8589



### Summary
This PR updates the FAQ accordion component so that a question automatically opens when the page is loaded with a matching URL hash.
For example: visiting
[/support#i-installed-my-own-sim-card-but-its-not-working](https://comma.ai/support#i-would-like-to-match-a-price-change)
will pre-open the relevant FAQ entry.

### Changes
Added logic to read the current window.location.hash on mount.

Auto-expands the corresponding FAQ accordion item if the hash matches.

Keeps the hash in sync when a new accordion item is expanded.

Why
Improves user experience by directly showing the relevant answer when users follow a support link with a hash.

Issue
Fixes #142