### PR TITLE
Error page text link hard to read

### DIFF
--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -12,6 +12,7 @@
 
 <style>
   .page {
+    --color-foreground: black;
     display: flex;
     flex-direction: column;
     align-items: center;
@@ -21,12 +22,10 @@
   }
 
   h1 {
-    color: black !important;
     margin: 3rem 0 1rem;
   }
 
   span {
-    color: black !important;
     font-size: 1.5rem;
     margin-top: 1rem;
   }

--- a/src/routes/+error.svelte
+++ b/src/routes/+error.svelte
@@ -4,7 +4,7 @@
   import CommaIcon from '$lib/icons/comma.svg?raw';
 </script>
 
-<div class="page">
+<div class="page light">
   {@html CommaIcon}
   <h1>{$page.error.message}</h1>
   <span>An issue occurred. <a class="highlight" href="/">Click here</a> to go back to the homepage.</span>
@@ -12,7 +12,6 @@
 
 <style>
   .page {
-    --color-foreground: black;
     display: flex;
     flex-direction: column;
     align-items: center;


### PR DESCRIPTION
- `app.css` has ` --color-foreground: white;` [Here](https://github.com/commaai/website/blob/81c609268baa9c7eb69776a54876f7f0e860dd9a/src/app.css#L42)
- use existing `.light` utility class

<br>

View error page here -> [https://comma.ai/comma10x](https://comma.ai/comma10x)

| Before | After |
|---------|--------|
| ![white-error](https://github.com/user-attachments/assets/3108a9a9-bced-48ef-b9d4-b742db16f116) | ![black-error](https://github.com/user-attachments/assets/bbf3007d-9db9-4e2e-b4eb-4a264cceec4e) |

