### PR TITLE
Normalise and strip diacritics in car search so skoda & škoda match

### DIFF
--- a/src/lib/components/CarSearch.svelte
+++ b/src/lib/components/CarSearch.svelte
@@ -22,7 +22,9 @@
 
   // Filter cars based on search input
   $: filteredCars = searchValue
-    ? uniqueCars.filter(car => car.toLowerCase().includes(searchValue.toLowerCase()))
+    ? uniqueCars.filter(car =>
+        normalizeAndStripDiacritics(car).includes(normalizeAndStripDiacritics(searchValue))
+      )
     : uniqueCars;
 
   // Reset highlighted index when filtered results change
@@ -32,6 +34,11 @@
     }
   } else {
     highlightedIndex = -1;
+  }
+
+  // Strip diacritics and normalize case so škoda matches skoda & Skoda
+  function normalizeAndStripDiacritics(str) {
+    return str.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "");
   }
 
   // Save selected car

--- a/src/lib/components/CarSearch.svelte
+++ b/src/lib/components/CarSearch.svelte
@@ -41,6 +41,7 @@
 
   // Strip diacritics and normalize case so škoda matches skoda & Skoda
   function normalizeAndStripDiacritics(str) {
+    if (!str) return '';
     return str.toLowerCase().normalize('NFD').replace(/[\u0300-\u036f]/g, "");
   }
 

--- a/src/lib/components/CarSearch.svelte
+++ b/src/lib/components/CarSearch.svelte
@@ -22,9 +22,12 @@
 
   // Filter cars based on search input
   $: filteredCars = searchValue
-    ? uniqueCars.filter(car =>
-        normalizeAndStripDiacritics(car).includes(normalizeAndStripDiacritics(searchValue))
-      )
+    ? (() => {
+        const normalizedSearch = normalizeAndStripDiacritics(searchValue);
+        return uniqueCars.filter(car =>
+          normalizeAndStripDiacritics(car).includes(normalizedSearch)
+        );
+      })()
     : uniqueCars;
 
   // Reset highlighted index when filtered results change


### PR DESCRIPTION
Tried looking for my car in the comma ai site and couldn't find it in search, realised it was due to accents on the **š** for skoda. this fixes matching for those cases.