### PR TITLE
Fix double highlight in car search

### DIFF
--- a/src/lib/components/CarSearch.svelte
+++ b/src/lib/components/CarSearch.svelte
@@ -178,8 +178,9 @@
           <div
             class="search-dropdown-item"
             class:highlighted={highlightedIndex === index}
+            class:selected={$selectedCar === car}
             role="option"
-            aria-selected={$selectedCar === car || highlightedIndex === index}
+            aria-selected={highlightedIndex === index}
             tabindex="-1"
             on:click={() => saveSelectedCar(car)}
             on:keydown={(e) => handleDropdownItemKeyDown(e, car)}
@@ -381,6 +382,13 @@
       &.highlighted {
         color: var(--color-accent);
       }
+
+        /* Saved selection state when not the active highlight */
+        &.selected:not(.highlighted) {
+          text-decoration: underline;
+          text-underline-offset: 0.2em;
+          opacity: 0.85;
+        }
 
       @media (hover: hover) and (pointer: fine) {
         &:hover {

--- a/src/lib/components/CarSearch.svelte
+++ b/src/lib/components/CarSearch.svelte
@@ -14,6 +14,7 @@
   let searchInputRef;
   let dropdownRef;
   let highlightedIndex = -1;
+  let usingKeyboard = false;
 
   // Get unique car names from vehicle harnesses only (excludes generic/developer harnesses)
   $: uniqueCars = $vehicleHarnesses
@@ -111,6 +112,7 @@
 
     if (e.key === 'ArrowDown') {
       e.preventDefault();
+      usingKeyboard = true;
       highlightedIndex = highlightedIndex < filteredCars.length - 1 ? highlightedIndex + 1 : 0;
       scrollIntoView(highlightedIndex);
       return;
@@ -118,6 +120,7 @@
 
     if (e.key === 'ArrowUp') {
       e.preventDefault();
+      usingKeyboard = true;
       highlightedIndex = highlightedIndex > 0 ? highlightedIndex - 1 : filteredCars.length - 1;
       scrollIntoView(highlightedIndex);
       return;
@@ -136,6 +139,12 @@
       e.preventDefault();
       saveSelectedCar(car);
     }
+  }
+
+  // Don't double highlight when mouse on an item and keyboard nav's to other item
+  function handleDropdownItemMouseEnter(index) {
+    usingKeyboard = false;
+    highlightedIndex = index;
   }
 </script>
 
@@ -163,7 +172,7 @@
     </button>
   {/if}
   {#if showDropdown}
-    <div class="search-dropdown" bind:this={dropdownRef}>
+    <div class="search-dropdown" class:disable-hover={usingKeyboard} bind:this={dropdownRef}>
       {#if filteredCars.length > 0}
         {#each filteredCars as car, index}
           <div
@@ -174,7 +183,7 @@
             tabindex="-1"
             on:click={() => saveSelectedCar(car)}
             on:keydown={(e) => handleDropdownItemKeyDown(e, car)}
-            on:mouseenter={() => highlightedIndex = index}
+            on:mouseenter={() => handleDropdownItemMouseEnter(index)}
           >
             {car}
           </div>
@@ -397,6 +406,10 @@
         pointer-events: none;
       }
     }
+
+      & .search-dropdown.disable-hover .search-dropdown-item:hover {
+        color: #ffffff;
+      }
 
     /*@media only screen and (max-width: 1280px) {*/
     /*  & {*/


### PR DESCRIPTION
<img width="1624" height="1056" alt="Screenshot 2025-11-09 at 3 05 25 AM" src="https://github.com/user-attachments/assets/6c11ff6e-a39d-49d0-968b-a91376ad306e" />

Previously, when mouse was on a search item and you used arrow keys, both the item under cursor would be highlighted as well as the one you moved to with arrows.
Changed so that only most recent movement is highlighted.

So:- 

1. Scrolling with cursor and press arrow keys (doesn't double highlight any more)
2. Index is tracked correctly
