### PR TITLE
Selected car applies to product pages

### DIFF
--- a/src/lib/components/CarSearch.svelte
+++ b/src/lib/components/CarSearch.svelte
@@ -1,10 +1,13 @@
 <script>
+  import { createEventDispatcher } from "svelte";
   import { browser } from "$app/environment";
   import { vehicleHarnesses } from '$lib/utils/harnesses';
   import { clickOutside } from '$lib/utils/clickOutside';
   import { selectedCar } from '../../store';
   import SearchIcon from "$lib/icons/ui/search.png";
   import CloseIcon from "$lib/icons/ui/close.svg?raw";
+
+  const dispatch = createEventDispatcher();
 
   // Search functionality
   let searchValue = "";
@@ -39,6 +42,7 @@
     selectedCar.set(car);
     searchValue = car;
     showDropdown = false;
+    dispatch("carSelected", { car });
   }
 
   // Clear selection

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -7,6 +7,7 @@
   import "@fontsource/inter/700.css";
   import '@fontsource/jetbrains-mono/400.css';
 
+  import { browser } from "$app/environment";
   import { get } from "svelte/store";
 
   import Badge from "$lib/components/Badge.svelte";
@@ -68,6 +69,13 @@
   });
 
   printConsoleBanner();
+
+  function handleCarSelected() {
+    if (!browser) return;
+    if ($page.url.pathname !== "/") return;
+    const buyButton = document.querySelector(".buy-now-button");
+    buyButton?.scrollIntoView({ behavior: "smooth", block: "center" });
+  }
 </script>
 
 <svelte:head>
@@ -95,7 +103,7 @@
       <a href="/jobs" class="hide-mobile-2" class:active={$page.url.pathname.startsWith('/jobs')}>jobs</a>
     </nav>
     <div class="navbar-section-search">
-      <CarSearch />
+      <CarSearch on:carSelected={handleCarSelected} />
     </div>
     <div class="navbar-section-buttons">
       <!-- <a class="button shop" href="/shop">

--- a/src/routes/shop/[product]/+page.js
+++ b/src/routes/shop/[product]/+page.js
@@ -50,7 +50,8 @@ export async function load({ url, params }) {
           ...productInfo,
           images: resolvedImages
         },
-        descriptionComponent
+        descriptionComponent,
+        productId
       };
     }
     throw error(404, {

--- a/src/routes/shop/[product]/+page.svelte
+++ b/src/routes/shop/[product]/+page.svelte
@@ -1,9 +1,18 @@
 <script>
   import Product from "$lib/components/Product.svelte";
   import NoteCard from "$lib/components/NoteCard.svelte";
+  import { selectedCar } from "../../../store.js";
+  import { vehicleHarnesses } from "$lib/utils/harnesses.js";
 
   export let data;
-  $: ({ product, descriptionComponent } = data);
+  $: ({ product, descriptionComponent, productId } = data);
+
+  const harnessBundledProducts = new Set(['comma-four']);
+  $: shouldBundleHarness = harnessBundledProducts.has(productId);
+  $: selectedHarness = shouldBundleHarness && $selectedCar && $vehicleHarnesses
+    ? $vehicleHarnesses.find((h) => h.car === $selectedCar) ?? null
+    : null;
+  $: bundledHarnessIds = shouldBundleHarness && selectedHarness?.id ? [selectedHarness.id] : [];
 </script>
 
 <svelte:head>
@@ -19,6 +28,7 @@
         {product}
         backordered={product.backordered || null}
         forceOutOfStock={product.forceOutOfStock || false}
+        additionalProductIds={bundledHarnessIds}
       >
         <div slot="notes">
           {#if product.notes}


### PR DESCRIPTION
I noticed two little issues with car selection when ordering a comma 4 that could result in no harness being added to the cart.

1. Selecting a car from the homepage offers no feedback and you must click the 'buy now' button that may only be visible after scrolling down. This lead me to navigate to the product page directly where I hit (2)
2. Selecting a car from the product page has no effect.

## Changes

- /shop/product pages respect selectedCar
- homepage scrolls to 'buy now' button when car selected

## Before/After

Before:

https://github.com/user-attachments/assets/0766a8b5-0000-489a-9339-9cb25d943481


After:

https://github.com/user-attachments/assets/cd6c47ce-7339-406b-9416-4c71db2f3bb3

Thanks for all your work!

