### PR TITLE
Add car harness image to "In the Box" section

### DIFF
--- a/src/routes/shop/comma-four/+page.svelte
+++ b/src/routes/shop/comma-four/+page.svelte
@@ -11,6 +11,7 @@
   import FourImage from "$lib/images/products/comma-four/four_screen_on.png";
   import OBDCCableImage from "$lib/images/products/obd-c-cable/obd-c-cable-four.png";
   import ReplacementMountsImage from "$lib/images/products/replacement-mounts/replacement-mounts-four.png";
+  import CarHarnessImage from "$lib/images/products/car-harness/car-harness.jpg";
   import CarBrandCollageImage from "$lib/images/car-brand-collage.jpg";
   import CoolingImage from "$lib/images/products/comma-four/cooling.png";
   import DeviceFrameImage from "$lib/images/products/comma-four/four_front.png";
@@ -63,6 +64,10 @@
         <div>
           <img src={ReplacementMountsImage} loading="lazy" alt="mount">
           <p>2 mounts</p>
+        </div>
+        <div>
+          <img src={CarHarnessImage} loading="lazy" alt="car harness">
+          <p>car harness <span style="color: var(--color-muted)">(optional)</span></p>
         </div>
       </div>
     </Grid>
@@ -389,21 +394,21 @@
     }
 
     & .box-contents {
-      display: flex;
-      flex-wrap: wrap;
+      display: grid;
+      grid-template-columns: repeat(2, 1fr);
+      gap: 2rem;
       text-align: center;
 
-      & > div {
-        width: 300px;
-        margin-bottom: 2rem;
+      @media screen and (max-width: 768px) {
+        grid-template-columns: 1fr;
+      }
 
-        & img {
-          max-height: 150px;
-        }
+      & img {
+        max-height: 150px;
+      }
 
-        & p {
-          margin: 0 2rem;
-        }
+      & p {
+        margin: 0 2rem;
       }
     }
 


### PR DESCRIPTION
- made the "In the box" section have the optional harness
- switched to grid so that it is either a 2x2 grid or stacked versus having a widow item for certain screens sizes
- also fixes items to be centered when they are stacked as seen in 2nd vid

# Different screen sizes

https://github.com/user-attachments/assets/8b85e8bb-6526-4ef5-a9de-98c65bc842cc

<br>

# Fixes items to be centered when mobile

![fixes-items-not-centered](https://github.com/user-attachments/assets/c64e2e60-bae3-4fe4-ad44-3da94d0724b4)

