### PR TITLE
Remove unused selectedCar localStorage code

### DIFF
--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -6,7 +6,6 @@
   import { tick } from 'svelte';
   import { clickOutside } from '$lib/utils/clickOutside';
   import { allHarnesses, vehicleHarnesses, genericHarnesses } from '$lib/utils/harnesses';
-  import { selectedCar } from '../../../store';
   import { NO_HARNESS_OPTION } from '$lib/constants/vehicles.js';
 
   import NoteCard from '$lib/components/NoteCard.svelte';
@@ -38,13 +37,6 @@
     // Don't update w/ initial state
     onChange(selection);
     updateQueryParams(selection);
-
-    // remember with cookie
-    if (selection?.car) {
-      selectedCar.set(selection.car);
-    } else {
-      selectedCar.set('');
-    }
   }
 
   function updateQueryParams(selectedHarness) {

--- a/src/store.js
+++ b/src/store.js
@@ -14,14 +14,6 @@ export const cartTotalQuantity = writable(browser ? window.localStorage.getItem(
 export const cartItems = writable([]);
 export const cartDiscount = writable({});
 export const cartSubtotal = writable({});
-export const selectedCar = writable(browser ? localStorage.getItem('selectedCar') || '' : '');
-
-if (browser) {
-  selectedCar.subscribe((value) => {
-    if (value) localStorage.setItem('selectedCar', value);
-    else localStorage.removeItem('selectedCar');
-  });
-}
 
 if (browser) {
   cartId.subscribe((value) => window.localStorage.cartId = value)


### PR DESCRIPTION
- HarnessSelector uses URL params as source of truth, not localStorage
- `selectedCar` store wrote to localStorage but nothing ever read it back
- Using URL param is a more predictable UX when sharing links for users versus storing previous selection