### PR TITLE
Update Shopify API to 2026-01

### DIFF
--- a/.env
+++ b/.env
@@ -1,3 +1,3 @@
-VITE_SHOPIFY_API_VERSION=2025-01 # Update this as needed once any breaking changes are resolved
+VITE_SHOPIFY_API_VERSION=2026-01 # Update this as needed once any breaking changes are resolved
 VITE_SHOPIFY_STORE_URL=comma-dev.myshopify.com # e.g. store.myshopify.com (without protocol)
-VITE_SHOPIFY_STOREFRONT_API_TOKEN=ee9baaeb9964250671e3abe92cef70e6 
+VITE_SHOPIFY_STOREFRONT_API_TOKEN=ee9baaeb9964250671e3abe92cef70e6


### PR DESCRIPTION
2025-01 is no longer supported, but I guess it just defaults the oldest supported (2025-04). It doesn't look like there are any breaking changes right now.