### PR TITLE
Add setup notes for Mazda vehicles

### DIFF
--- a/src/lib/vehicles.json
+++ b/src/lib/vehicles.json
@@ -3260,6 +3260,7 @@
       "footnotes": [
       ],
       "setup_notes": [
+        "See more setup details for \u003ca href=\"https://github.com/commaai/openpilot/wiki/mazda\" target=\"_blank\"\u003eMazda\u003c/a\u003e."
       ]
     },
     {
@@ -3275,6 +3276,7 @@
       "footnotes": [
       ],
       "setup_notes": [
+        "See more setup details for \u003ca href=\"https://github.com/commaai/openpilot/wiki/mazda\" target=\"_blank\"\u003eMazda\u003c/a\u003e."
       ]
     }
   ],


### PR DESCRIPTION
Add link to the wiki page for Mazda vehicles to inform users of the Comma Power requirement.