### PR TITLE
Setup Guide: Make it clear when comma power is required

### DIFF
--- a/src/lib/compatibility-meta.json
+++ b/src/lib/compatibility-meta.json
@@ -1,3 +1,3 @@
 {
-  "last_updated": "June 13, 2026"
+  "last_updated": "June 21, 2026"
 }

--- a/src/lib/utils/harnesses.js
+++ b/src/lib/utils/harnesses.js
@@ -44,6 +44,7 @@ async function initializeHarnesses() {
         backordered: harness?.backordered,  // these overrides are only shown if the harness is out of stock in Shopify
         setupNotes: model.setup_notes,
         setupVideo: model.setup_video,
+        requiresCommaPower: model.requires_comma_power === true,
       };
     }).filter(Boolean);
   });

--- a/src/lib/vehicles.json
+++ b/src/lib/vehicles.json
@@ -3336,7 +3336,9 @@
       "footnotes": [
       ],
       "setup_notes": [
-      ]
+        "Mazda vehicles \u003cb\u003erequire\u003c/b\u003e comma power installation."
+      ],
+      "requires_comma_power": true
     },
     {
       "name": "Mazda CX-9 2021-23",
@@ -3351,7 +3353,9 @@
       "footnotes": [
       ],
       "setup_notes": [
-      ]
+        "Mazda vehicles \u003cb\u003erequire\u003c/b\u003e comma power installation."
+      ],
+      "requires_comma_power": true
     }
   ],
   "Nissan": [

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -271,7 +271,7 @@
     </div>
 
     <hr />
-    <div class="step" id="step-6">
+    <div class="step" id="comma-power-step">
       <Badge style="dark">
         {#if requiresCommaPower}
           Step 6 <span class="muted">of {totalSteps}</span>
@@ -306,7 +306,7 @@
     </div>
 
     <hr />
-    <div class="step">
+    <div class="step" id="comma-connect-step">
       <Badge style="dark">OPTIONAL STEP</Badge>
       <h2>Pair your device with comma connect</h2>
       <Grid templateColumns="0.875fr 0.75fr">

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -279,7 +279,7 @@
           OPTIONAL STEP
         {/if}
       </Badge>
-      <h2>{requiresCommaPower ? "Install comma power" : "Add the comma power"}</h2>
+      <h2>Add the comma power</h2>
       <Grid templateColumns="0.875fr 0.75fr">
         <div>
           <img src={CommaPowerImage} loading="lazy" alt="comma power" />

--- a/src/routes/setup/+page.svelte
+++ b/src/routes/setup/+page.svelte
@@ -38,6 +38,8 @@
   const handleHarnessSelection = (value) => {
     selectedVehicle = value;
   }
+  $: requiresCommaPower = selectedVehicle?.requiresCommaPower === true;
+  $: totalSteps = requiresCommaPower ? 6 : 5;
 
   function getVideoEmbedSrc(videoLink) {
     const url = new URL(videoLink);
@@ -71,7 +73,7 @@
           <div class="overview">
             <div>
               {@html RecordingsIcon}
-              <span>5 steps</span>
+              <span>{totalSteps} steps</span>
             </div>
             <div class="divider" />
             <div>
@@ -173,7 +175,7 @@
     </div>
 
         <div class="step" id="step-1">
-      <Badge style="dark">Step 1 <span class="muted">of 5</span></Badge>
+      <Badge style="dark">Step 1 <span class="muted">of {totalSteps}</span></Badge>
       <h2>Remove the rearview mirror cover trim</h2>
       <Grid templateColumns="0.875fr 0.75fr">
         <div class="image-grid">
@@ -192,7 +194,7 @@
     </div>
     <hr />
     <div class="step" id="step-2">
-      <Badge style="dark">Step 2 <span class="muted">of 5</span></Badge>
+      <Badge style="dark">Step 2 <span class="muted">of {totalSteps}</span></Badge>
       <h2>Connect car harness into the camera</h2>
       <Grid templateColumns="0.875fr 0.75fr">
         <div class="image-grid">
@@ -213,7 +215,7 @@
     </div>
     <hr />
     <div class="step" id="step-3">
-      <Badge style="dark">Step 3 <span class="muted">of 5</span></Badge>
+      <Badge style="dark">Step 3 <span class="muted">of {totalSteps}</span></Badge>
       <h2>Place mount high and centered on the windshield</h2>
       <Grid templateColumns="0.875fr 0.75fr">
         <div class="image-grid">
@@ -235,7 +237,7 @@
     </div>
     <hr />
     <div class="step" id="step-4">
-      <Badge style="dark">Step 4 <span class="muted">of 5</span></Badge>
+      <Badge style="dark">Step 4 <span class="muted">of {totalSteps}</span></Badge>
       <h2>Plug in OBD-C and mount the device</h2>
       <Grid templateColumns="0.875fr 0.75fr">
         <div class="image-grid">
@@ -252,7 +254,7 @@
     </div>
     <hr />
     <div class="step" id="step-5">
-      <Badge style="dark">Step 5 <span class="muted">of 5</span></Badge>
+      <Badge style="dark">Step 5 <span class="muted">of {totalSteps}</span></Badge>
       <h2>Reinstall the rearview mirror cover trim</h2>
       <Grid templateColumns="0.875fr 0.75fr">
         <div class="image-grid">
@@ -265,6 +267,41 @@
           <li>Ensure the car harness fully fits inside the trim.</li>
           <li>Generally, it's best to have the OBD-C cable come out of the top.</li>
         </ul>
+      </Grid>
+    </div>
+
+    <hr />
+    <div class="step" id="step-6">
+      <Badge style="dark">
+        {#if requiresCommaPower}
+          Step 6 <span class="muted">of {totalSteps}</span>
+        {:else}
+          OPTIONAL STEP
+        {/if}
+      </Badge>
+      <h2>{requiresCommaPower ? "Install comma power" : "Add the comma power"}</h2>
+      <Grid templateColumns="0.875fr 0.75fr">
+        <div>
+          <img src={CommaPowerImage} loading="lazy" alt="comma power" />
+        </div>
+        <div>
+          <p>
+            {#if requiresCommaPower}
+              Installing comma power is required for this vehicle.
+            {:else}
+              Installing the comma power is entirely optional and can be done at any time.
+            {/if}
+            Simply connect one end to your car's OBD-II port and the other to the harness box.
+          </p>
+          <p>
+            With a comma power:
+          </p>
+          <ul>
+            <li>The start and end of every drive are recorded.</li>
+            <li>Your comma four remains powered and online while the car is off.</li>
+            <li>Your comma four downloads updates while the car is off.</li>
+          </ul>
+        </div>
       </Grid>
     </div>
 
@@ -282,31 +319,6 @@
           </p>
           <br />
           <LinkButton href="https://connect.comma.ai/" target="_blank" style="primary" fullWidth={true}>comma Connect</LinkButton>
-        </div>
-      </Grid>
-    </div>
-
-    <hr />
-    <div class="step">
-      <Badge style="dark">OPTIONAL STEP</Badge>
-      <h2>Add the comma power</h2>
-      <Grid templateColumns="0.875fr 0.75fr">
-        <div>
-          <img src={CommaPowerImage} loading="lazy" alt="comma power" />
-        </div>
-        <div>
-          <p>
-            Installing the comma power is entirely optional and can be done at any time.
-            Simply connect one end to your car's OBD-II port and the other to the harness box.
-          </p>
-          <p>
-            With a comma power:
-          </p>
-          <ul>
-            <li>The start and end of every drive are recorded.</li>
-            <li>Your comma four remains powered and online while the car is off.</li>
-            <li>Your comma four downloads updates while the car is off.</li>
-          </ul>
         </div>
       </Grid>
     </div>

--- a/templates/vehicles_template.json
+++ b/templates/vehicles_template.json
@@ -22,7 +22,8 @@
         {% for footnote in car.footnotes if footnote.value.setup_note %}
         {{ footnote.value.text | tojson }}{{ "" if loop.last else "," }}
         {% endfor %}
-      ]
+      ]{% if car.requires_comma_power %},
+      "requires_comma_power": true{% endif +%}
     }{{ "" if loop.last else "," }}
     {% endfor %}
   ]{{ "" if loop.last else "," }}


### PR DESCRIPTION
## Proposed Changes

Behavior of setup guide when Mazda is selected:
- the setup note from opendbc repo appear vs saying "There are no specific setup notes for your vehicle."
- comma power is **not** an "Optional Step" and is listed as step 6
- in comma power step, update copy to say comma power is required vs optional

When a non-Mazda car is selected:
- biggest difference is that comma power optional step shows before comma connect optional step


# UI compare
| Before | After |
| ------- | ------- |
| <video src="https://github.com/user-attachments/assets/acbcefa2-59a7-4609-8291-4fcdfb602679"></video> | <video src="https://github.com/user-attachments/assets/71090db1-ad0a-48c7-93ce-dd59264ac727"></video> |





---

I can split this into multiple PRs like below, lmk:
- move comma power before comma connect optional step
- wire required comma power flag into setup data flow
- update data
- add comma power UI/UX changes

Related PR opendbc with problem context: https://github.com/commaai/opendbc/pull/3492