### PR TITLE
leaderboard: add VeigaPunk controls challenge 6.880

### DIFF
--- a/static/leaderboard.html
+++ b/static/leaderboard.html
@@ -322,6 +322,7 @@ We designed these challenges around real problems we've faced while building and
     <tr> <td></td> <td>6.880</td> <td><a href="https://github.com/RyanL2">RyanL2</a>&nbsp;👑<td>per segment direct quadratic optimization</td> </tr>
     <tr> <td></td> <td>6.880</td> <td><a href="https://github.com/hypery11">hypery11</a>&nbsp;👑<td>per segment direct quadratic optimization</td> </tr>
     <tr> <td></td> <td>6.880</td> <td><a href="https://github.com/pmazumder3927">pmazumder3927</a>&nbsp;👑<td>per segment direct quadratic optimization</td> </tr>
+    <tr> <td></td> <td>6.880</td> <td><a href="https://github.com/VeigaPunk">VeigaPunk</a>&nbsp;👑<td>per segment direct quadratic optimization</td> </tr>
     <tr> <td></td> <td>7.083</td> <td><a href="https://github.com/Vansh404">Vansh404</a></td> <td>online simulator probing with rng reset </td> </tr>
     <tr> <td></td> <td>7.228</td> <td><a href="https://github.com/Yezus69">Yezus69</a><td>per segment optimized actions</td> </tr>
     <tr> <td></td> <td>13.593</td> <td><a href="https://github.com/auriium2">auriium2</a><td>per segment MPC</td> </tr>


### PR DESCRIPTION
## Summary
Add **VeigaPunk** to the controls challenge leaderboard at **6.880** (co-#1 / metric floor).

| Field | Value |
|-------|--------|
| Score | **6.880** (`total_cost` mean over 5000 segs = 6.880472) |
| Method | per segment direct quadratic optimization (Tikhonov) |
| Code | https://github.com/VeigaPunk/comma-controls-challenge |
| Score doc | https://github.com/VeigaPunk/comma-controls-challenge/blob/main/SCORE.md |
| Form | submitted (report.html + zip) |
| Email | work@comma.ai (+ report attach) |

## Verify
```bash
python eval.py --model_path ./models/tinyphysics.onnx --data_path ./data \
  --num_segs 5000 --test_controller continuous_lookup_noclip --baseline_controller pid
```

## Notes
Same method class as existing crown (RyanL2 / hypery11 / pmazumder3927). One-line HTML change. CI green. If staff prefer landing from the form queue, happy to close this PR once the row is live.