### PR TITLE
design LB: add VeigaPunk Horizon Halo (comma four / post-Qt)

### DIFF
--- a/static/leaderboard.html
+++ b/static/leaderboard.html
@@ -449,6 +449,7 @@ We designed these challenges around real problems we've faced while building and
       <th>name</th> <th>design</th>
   </tr></thead>
   <tbody>
+    <tr> <td><a href="https://github.com/VeigaPunk">VeigaPunk</a></td> <td><a href="https://veigapunk.github.io/horizon-halo-comma-design/">design</a></td> </tr>
     <tr> <td><a href="https://github.com/ugtthis">davidcalifornia</a></td> <td><a href="https://publish.obsidian.md/typedbyhumans/comma/Driver+Alert+Dial+aka+DAD">design</a></td> </tr>
     <tr> <td><a href="https://github.com/utkarshgill">utkarshgill</a></td> <td><a href="https://www.figma.com/design/JpgZUyEQHtRSTsQKRPJI4m/comma?node-id=639-266&t=TegDnviRtLE3qfAX-1">design</a></td> </tr>
     <tr> <td><a href="https://github.com/hyusap">hyusap</a></td> <td><a href="https://comma.ayush.digital/">design</a></td> </tr>


### PR DESCRIPTION
## design LB: add VeigaPunk (Horizon Halo)

Adds first-row design-challenge listing for **VeigaPunk / Horizon Halo**.

### Links
- **Interactive (comma four target):** https://veigapunk.github.io/horizon-halo-comma-design/
- **Source:** https://github.com/VeigaPunk/horizon-halo-comma-design
- **Medium writeup:** https://medium.com/@jpveigao10/horizon-halo-openpilot-confidence-ui-for-comma-design-challenge-ed251ba10301
- **Google Form:** response recorded 2026-07-22 (challenge=design, show on leaderboard=yes)
- **Preview:** https://comma-web--pr335-opltfoa1.web.app/leaderboard#design_challenge

### Maintainer feedback addressed
@sshane noted Qt is gone and **comma four** is the headlining hardware. Demo + writeup revised 2026-07-22 to target comma four / modern UI stack (post-Qt), keeping peripheral Horizon Halo + actuator headroom.

### Why merge
- Design LB is staff-maintained only; form alone does not publish rows
- One-line HTML add; CI green; mergeable clean
- Job filled note acknowledged — challenge still active for the leaderboard

Thanks for any merge when free.