### PR TITLE
chestnut: update Discord channel name (#hw-chestnut -> #chestnut)

### DIFF
--- a/src/routes/shop/chestnut/+page.svelte
+++ b/src/routes/shop/chestnut/+page.svelte
@@ -200,7 +200,7 @@
               USB cable, a car power cable, and mounting strips.
             </p>
             <p class="usage-link">
-              Join the #hw-chestnut channel on <a class="highlight" href="https://discord.comma.ai/">Discord</a>.
+              Join the #chestnut channel on <a class="highlight" href="https://discord.comma.ai/">Discord</a>.
             </p>
           </article>
         </div>


### PR DESCRIPTION
Fixes this incorrect recommendation on the chestnut shop page.
<img width="410" height="61" alt="image" src="https://github.com/user-attachments/assets/108e16d3-686b-43de-8540-2f9a9b37e305" />
