### PR TITLE
Fix car harness search

### DIFF
--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -162,7 +162,7 @@
     <span class="chevron">{@html ChevronIcon}</span>
   </div>
   <div class="dropdown-content" class:show={menuOpen}>
-    {#if inputValue !== ''}
+    {#if searchTerms.length > 0}
       {#if filteredItems.length > 0}
         {#each filteredItems as item}
           <DropdownItem value={item} on:click={() => handleOptionClick(item)} on:keydown={(e) => handleOptionKeyDown(e, item)} />

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -89,7 +89,7 @@
 
   $: searchTerms = normalizeDiacritics(inputValue.toLowerCase()).split(/\s+/).filter(Boolean);
   $: filteredItems = $harnesses.filter(item => {
-    const car = normalizeDiacritics(item.car.toLowerCase());
+    const car = normalizeDiacritics(`${item.car} ${item.yearList ?? ''}`.toLowerCase());  // add all years in range
     return searchTerms.every(term => car.includes(term));
   });
 

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -87,9 +87,11 @@
   let inputValue = "";
   let inputRef;
 
-  $: filteredItems = $harnesses.filter(item =>
-    normalizeDiacritics(item.car.toLowerCase()).match(normalizeDiacritics(inputValue.toLowerCase()))
-  );
+  $: searchTerms = normalizeDiacritics(inputValue.toLowerCase()).split(/\s+/).filter(Boolean);
+  $: filteredItems = $harnesses.filter(item => {
+    const car = normalizeDiacritics(item.car.toLowerCase());
+    return searchTerms.every(term => car.includes(term));
+  });
 
   const handleClear = () => {
     // clear search input or close menu

--- a/src/lib/utils/harnesses.js
+++ b/src/lib/utils/harnesses.js
@@ -40,6 +40,7 @@ async function initializeHarnesses() {
         ...harness,
         make,
         car: model.name,
+        yearList: model.year_list?.replaceAll(',', ''),
         package: model.package,
         backordered: harness?.backordered,  // these overrides are only shown if the harness is out of stock in Shopify
         setupNotes: model.setup_notes,


### PR DESCRIPTION
`(` broke the search until refresh, it only checked in order (`2024 camry` didn't work), needed exact matches, and didn't find the car if you searched 23 if the range was 2020-25. Now partial searches like `Gen GV8 23` and `24 cam` work

before:

<img width="535" height="340" alt="image" src="https://github.com/user-attachments/assets/d6a585ad-0c2c-4f53-9b0f-21a7ed1adb94" />

<img width="569" height="271" alt="image" src="https://github.com/user-attachments/assets/e71e65e9-78df-4f2e-aeea-9ddacb54bc9b" />

after:

<img width="519" height="335" alt="image" src="https://github.com/user-attachments/assets/b0c66d8e-9451-437c-ae7e-50d0782212b8" />

<img width="496" height="410" alt="image" src="https://github.com/user-attachments/assets/e2fff46d-1f71-4514-8171-8c12bfcbe50c" />

---

searches using this string:

<img width="507" height="156" alt="image" src="https://github.com/user-attachments/assets/1c51e90c-93be-42d1-bc3e-fcd7f6a5210a" />
