### PR TITLE
Good car search

### DIFF
--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -80,19 +80,28 @@
     }
   }
 
-  // Normalize diacritics for matching (e.g., "Škoda" -> "Skoda")
-  function normalizeDiacritics(str) {
-    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '');
+  // Normalize for matching: diacritics (e.g., "Škoda" -> "skoda") and punctuation (e.g., "CR-V" -> "crv")
+  function normalize(str) {
+    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[-.]/g, '').toLowerCase();
   }
+
+  // Shorthand added to a vehicle's searchable text when it contains the word (e.g., "ev" finds "Ioniq Electric")
+  const SEARCH_ALIASES = Object.entries({
+    electric: 'ev',
+    volkswagen: 'vw',
+    chevrolet: 'chevy',
+  });
 
   /* Filtered Dropdown */
   let inputValue = "";
   let inputRef;
 
-  $: searchTerms = normalizeDiacritics(inputValue.toLowerCase()).split(/\s+/).filter(Boolean);
+  $: searchTerms = normalize(inputValue).split(/\s+/).filter(Boolean);
   $: filteredItems = $harnesses.filter(item => {
-    const car = normalizeDiacritics(`${item.car} ${item.yearList ?? ''}`.toLowerCase())  // add all years in range
-      .replace('electric', 'electric ev');  // so "ev" finds electric vehicles
+    const car = SEARCH_ALIASES.reduce(
+      (car, [word, alias]) => car.replace(word, `${word} ${alias}`),
+      normalize(`${item.car} ${item.yearList ?? ''}`),  // add all years in range
+    );
     return searchTerms.every(term => car.includes(term));
   });
 

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -80,15 +80,15 @@
     }
   }
 
-  // Normalize for matching: strip diacritics, punctuation, and attach word/number boundaries ("Ioniq 5" -> "ioniq5")
+  // Strip diacritics and punctuation, attach model numbers but not years ("Ioniq 5" -> "ioniq5")
   function normalize(str) {
-    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/([a-z]) (?=[0-9])/g, '$1');
+    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/([a-z]) (?=[0-9]{1,3}(?:\s|$))/g, '$1');
   }
 
   // Common misspellings and shorthands
   const SEARCH_ALIASES = Object.entries({
-    ev: 'electric',
-    bev: 'electric',
+    ev: 'electri',  // electric and electrified
+    bev: 'electri',
     vw: 'volkswagen',
     chevy: 'chevrolet',
     subie: 'subaru',
@@ -114,14 +114,20 @@
   let inputValue = "";
   let inputRef;
 
+  // Where each term matches: 0 starts the name, 1 starts a word or alias, 2 is inside a word, Infinity is no match
+  function searchScore(item, terms) {
+    const car = normalize([item.make, item.model, item.yearList].filter(Boolean).join(' '));  // each year, not the range string
+    const aliases = SEARCH_ALIASES.filter(([, word]) => car.includes(word));
+    return terms.reduce((total, term) => total
+      + (car.startsWith(term) ? 0
+      : car.includes(` ${term}`) || aliases.some(([alias]) => alias.startsWith(term)) ? 1
+      : car.includes(term) ? 2
+      : Infinity), 0);
+  }
+
   $: searchTerms = inputValue.split(/\s+/).map(normalize).filter(Boolean);
-  $: filteredItems = $harnesses.filter(item => {
-    const car = SEARCH_ALIASES.reduce(
-      (car, [alias, word]) => car.includes(word) ? `${car} ${alias}` : car,
-      normalize(`${item.car} ${item.yearList ?? ''}`),  // add all years in range
-    );
-    return searchTerms.every(term => car.includes(term));
-  });
+  $: scores = new Map($harnesses.map(item => [item, searchScore(item, searchTerms)]));
+  $: filteredItems = $harnesses.filter(item => isFinite(scores.get(item))).sort((a, b) => scores.get(a) - scores.get(b));
 
   const handleClear = () => {
     // clear search input or close menu

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -80,9 +80,9 @@
     }
   }
 
-  // Strip diacritics and punctuation, attach model numbers but not years ("Ioniq 5" -> "ioniq5")
+  // Strip diacritics and punctuation ("Škoda" -> "skoda", "CR-V" -> "crv")
   function normalize(str) {
-    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/([a-z]) (?=[0-9]{1,3}(?:\s|$))/g, '$1');
+    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9\s]/g, '');
   }
 
   // Common misspellings and shorthands
@@ -116,7 +116,9 @@
 
   // Lower is a better match: 0 exact word, 1 starts the first word, 2 starts a later word or an alias, 3 inside a word, inf is no match
   function searchScore(item, terms) {
-    const car = normalize([item.make, item.model, item.yearList].filter(Boolean).join(' '));  // each year, not the range string
+    const model = normalize(item.model);
+    const joined = model.replace(/([a-z]) (?=[0-9])/g, '$1');  // "Ioniq 5" also matches "ioniq5"
+    const car = [normalize(item.make ?? ''), model, joined, item.yearList].filter(Boolean).join(' ');  // each year, not the range string
     const padded = ` ${car} `;
     const aliases = SEARCH_ALIASES.filter(([, word]) => car.includes(word));
     return terms.reduce((total, term) => total
@@ -127,9 +129,11 @@
       : Infinity), 0);
   }
 
-  $: searchTerms = inputValue.split(/\s+/).map(normalize).filter(Boolean);
+  $: searchTerms = normalize(inputValue).split(/\s+/).filter(Boolean);
   $: scores = new Map($harnesses.map(item => [item, searchScore(item, searchTerms)]));
-  $: filteredItems = $harnesses.filter(item => isFinite(scores.get(item))).sort((a, b) => scores.get(a) - scores.get(b));
+  // Generic harnesses have no make and rank after every car
+  $: filteredItems = $harnesses.filter(item => isFinite(scores.get(item)))
+    .sort((a, b) => !a.make - !b.make || scores.get(a) - scores.get(b));
 
   const handleClear = () => {
     // clear search input or close menu

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -85,15 +85,29 @@
     return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/([a-z]) (?=[0-9])/g, '$1');
   }
 
-  // Map search term to car names
+  // Common misspellings and shorthands
   const SEARCH_ALIASES = Object.entries({
     ev: 'electric',
     bev: 'electric',
     vw: 'volkswagen',
-    volkswagon: 'volkswagen',
     chevy: 'chevrolet',
     subie: 'subaru',
     obd2: 'obdii',
+
+    hundai: 'hyundai',
+    hyndai: 'hyundai',
+    hyundia: 'hyundai',
+    huyndai: 'hyundai',
+    volkswagon: 'volkswagen',
+    wolksvagen: 'volkswagen',
+    volkwagen: 'volkswagen',
+    totota: 'toyota',
+    toyata: 'toyota',
+    telsa: 'tesla',
+    chevorlet: 'chevrolet',
+    leksus: 'lexus',
+    auddi: 'audi',
+    jeeep: 'jeep',
   });
 
   /* Filtered Dropdown */

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -91,6 +91,7 @@
     bev: 'electric',
     vw: 'volkswagen',
     chevy: 'chevrolet',
+    subie: 'subaru',
   });
 
   /* Filtered Dropdown */

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -114,14 +114,16 @@
   let inputValue = "";
   let inputRef;
 
-  // Where each term matches: 0 starts the name, 1 starts a word or alias, 2 is inside a word, Infinity is no match
+  // Lower is a better match: 0 exact word, 1 starts the first word, 2 starts a later word or an alias, 3 inside a word, inf is no match
   function searchScore(item, terms) {
     const car = normalize([item.make, item.model, item.yearList].filter(Boolean).join(' '));  // each year, not the range string
+    const padded = ` ${car} `;
     const aliases = SEARCH_ALIASES.filter(([, word]) => car.includes(word));
     return terms.reduce((total, term) => total
-      + (car.startsWith(term) ? 0
-      : car.includes(` ${term}`) || aliases.some(([alias]) => alias.startsWith(term)) ? 1
-      : car.includes(term) ? 2
+      + (padded.includes(` ${term} `) ? 0
+      : car.startsWith(term) ? 1
+      : padded.includes(` ${term}`) || aliases.some(([alias]) => alias.startsWith(term)) ? 2
+      : car.includes(term) ? 3
       : Infinity), 0);
   }
 

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -80,9 +80,9 @@
     }
   }
 
-  // Normalize for matching: diacritics (e.g., "Škoda" -> "skoda") and punctuation
+  // Normalize for matching: strip diacritics, punctuation, and attach word/number boundaries ("Ioniq 5" -> "ioniq5")
   function normalize(str) {
-    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[-.]/g, '').toLowerCase();
+    return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').toLowerCase().replace(/[^a-z0-9\s]/g, '').replace(/([a-z]) (?=[0-9])/g, '$1');
   }
 
   // Map search term to car names
@@ -100,7 +100,7 @@
   let inputValue = "";
   let inputRef;
 
-  $: searchTerms = normalize(inputValue).split(/\s+/).filter(Boolean);
+  $: searchTerms = inputValue.split(/\s+/).map(normalize).filter(Boolean);
   $: filteredItems = $harnesses.filter(item => {
     const car = SEARCH_ALIASES.reduce(
       (car, [alias, word]) => car.includes(word) ? `${car} ${alias}` : car,

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -80,12 +80,12 @@
     }
   }
 
-  // Normalize for matching: diacritics (e.g., "Škoda" -> "skoda") and punctuation (e.g., "CR-V" -> "crv")
+  // Normalize for matching: diacritics (e.g., "Škoda" -> "skoda") and punctuation
   function normalize(str) {
     return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[-.]/g, '').toLowerCase();
   }
 
-  // Map search term to our car names
+  // Map search term to car names
   const SEARCH_ALIASES = Object.entries({
     ev: 'electric',
     bev: 'electric',

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -90,8 +90,10 @@
     ev: 'electric',
     bev: 'electric',
     vw: 'volkswagen',
+    volkswagon: 'volkswagen',
     chevy: 'chevrolet',
     subie: 'subaru',
+    obd2: 'obdii',
   });
 
   /* Filtered Dropdown */

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -85,11 +85,12 @@
     return str.normalize('NFD').replace(/[\u0300-\u036f]/g, '').replace(/[-.]/g, '').toLowerCase();
   }
 
-  // Shorthand added to a vehicle's searchable text when it contains the word (e.g., "ev" finds "Ioniq Electric")
+  // Map search term to our car names
   const SEARCH_ALIASES = Object.entries({
-    electric: 'ev',
-    volkswagen: 'vw',
-    chevrolet: 'chevy',
+    ev: 'electric',
+    bev: 'electric',
+    vw: 'volkswagen',
+    chevy: 'chevrolet',
   });
 
   /* Filtered Dropdown */
@@ -99,7 +100,7 @@
   $: searchTerms = normalize(inputValue).split(/\s+/).filter(Boolean);
   $: filteredItems = $harnesses.filter(item => {
     const car = SEARCH_ALIASES.reduce(
-      (car, [word, alias]) => car.replace(word, `${word} ${alias}`),
+      (car, [alias, word]) => car.includes(word) ? `${car} ${alias}` : car,
       normalize(`${item.car} ${item.yearList ?? ''}`),  // add all years in range
     );
     return searchTerms.every(term => car.includes(term));

--- a/src/lib/components/HarnessSelector/HarnessSelector.svelte
+++ b/src/lib/components/HarnessSelector/HarnessSelector.svelte
@@ -116,9 +116,8 @@
 
   // Lower is a better match: 0 exact word, 1 starts the first word, 2 starts a later word or an alias, 3 inside a word, inf is no match
   function searchScore(item, terms) {
-    const model = normalize(item.model);
-    const joined = model.replace(/([a-z]) (?=[0-9])/g, '$1');  // "Ioniq 5" also matches "ioniq5"
-    const car = [normalize(item.make ?? ''), model, joined, item.yearList].filter(Boolean).join(' ');  // each year, not the range string
+    const make_model = normalize([item.make, item.model].filter(Boolean).join(' '));
+    const car = `${make_model} ${make_model.replace(/([a-z]) (?=[0-9])/g, '$1')} ${item.yearList ?? ''}`;  // "Ioniq 5" also matches "ioniq5"
     const padded = ` ${car} `;
     const aliases = SEARCH_ALIASES.filter(([, word]) => car.includes(word));
     return terms.reduce((total, term) => total

--- a/src/lib/utils/harnesses.js
+++ b/src/lib/utils/harnesses.js
@@ -39,6 +39,7 @@ async function initializeHarnesses() {
         ...harnessInfo[harness.id],
         ...harness,
         make,
+        model: model.model,
         car: model.name,
         yearList: model.year_list?.replaceAll(',', ''),
         package: model.package,
@@ -54,6 +55,7 @@ async function initializeHarnesses() {
   let genericHarnessList = CarHarnesses.map(harness => {
     return {
       ...harnessInfo[harness.id],
+      model: harness.title,
       car: harness.title,
       id: harness.id,
       backordered: harness.backordered,


### PR DESCRIPTION
Strip punctuation and spaces so "crv" "hrv" "plugin" "ram1500" "ioniq5" all work

vw -> volkswagen
chevy -> chevrolet
bev -> electric
hev -> hybrid
and more

good sorting now too!

| Before | After |
| --- | --- |
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/b5ad661e-836e-4c73-b2f1-255404e8edde" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/31e2e1a0-29a8-4c3b-b4be-d7f4ed3f5d87" /> |
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/f028c7f3-66d0-41ea-9f75-4988bcae232d" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/0e3fe071-bef1-40e6-8dbd-a7ce4dab6512" /> |
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/49c0639b-1d1c-480c-a789-83064974ffb1" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/98d64658-290d-4d6a-9424-d1dae8294f72" /> |
| <img width="400" alt="before" src="https://github.com/user-attachments/assets/6be17cf1-f261-453e-ab67-ed787d209b56" /> | <img width="400" alt="after" src="https://github.com/user-attachments/assets/bed90912-30f4-4a4a-b307-30d51e3dea43" /> |
| <img width="542" height="567" alt="image" src="https://github.com/user-attachments/assets/ccb14e4b-0931-45e2-adea-617fb6ac1e5a" /> |<img width="529" height="550" alt="image" src="https://github.com/user-attachments/assets/688778ed-5553-4fd9-bf7a-6d45923678ba" /> |
| <img width="414" height="580" alt="image" src="https://github.com/user-attachments/assets/b4b2bbb1-c4b0-49a1-b047-7eae0a893a0c" /> | <img width="414" height="572" alt="image" src="https://github.com/user-attachments/assets/4053e9d7-cbf8-4939-9983-edb31e8cc520" /> |


extends on https://github.com/commaai/website/commit/db59367627e3b98d9368db111fe3c07542c76bec

sources: https://www.hotcars.com/the-most-commonly-misspelled-carmakers-youre-getting-wrong/, https://www.carsales.com.au/editorial/details/the-most-misspelled-car-brands-revealed-138282/