### PR TITLE
Show the sale banner site-wide

### DIFF
--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -23,6 +23,7 @@
   import { printConsoleBanner } from '$lib/utils/console';
   import { getReferralCode } from '$lib/utils/referral';
 
+  import HeaderBanner from "$lib/components/HeaderBanner.svelte";
   import HeaderMenu from "$lib/components/HeaderMenu.svelte";
   import ShoppingCart from "$lib/components/ShoppingCart.svelte";
   import {
@@ -118,6 +119,8 @@
     bind:loading
   />
 {/if}
+
+<HeaderBanner />
 
 <main>
   <slot></slot>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -4,7 +4,6 @@
   import FeaturedCarsList from "$lib/components/FeaturedCarsList.svelte";
   import TestimonialSection from "$lib/components/TestimonialSection.svelte";
   import HomeHeroOverlay from "$lib/components/HomeHeroOverlay.svelte";
-  import HeaderBanner from "$lib/components/HeaderBanner.svelte";
 
   import DeviceImage from "$lib/images/products/comma-four/four_front.png?w=1440";
   import DeviceScreenOnImage from "$lib/images/products/comma-four/four_screen_on.png?w=1440";
@@ -164,8 +163,6 @@
   <link rel="preload" as="image" href="{CDN_BASE}/hero-portrait/poster.jpg" media="(max-width: 768px)" />
   <link rel="preload" as="image" href="{CDN_BASE}/screen-video/poster.jpg" />
 </svelte:head>
-
-<HeaderBanner />
 
 <section
   class="hero-image"

--- a/src/routes/shop/+page.svelte
+++ b/src/routes/shop/+page.svelte
@@ -5,7 +5,6 @@
   import Accordion from "$lib/components/Accordion.svelte";
   import Button from "$lib/components/Button.svelte";
   import Badge from "$lib/components/Badge.svelte";
-  import HeaderBanner from "$lib/components/HeaderBanner.svelte";
 
   import FourImage from "$lib/images/products/comma-four/four_screen_on.png";
   import ChestnutImage from "$lib/images/products/chestnut/bnut_34.png";
@@ -47,8 +46,6 @@
     })
     .filter(Boolean);
 </script>
-
-<HeaderBanner />
 
 <section class="dark" id="devices">
   <div class="container">


### PR DESCRIPTION
Adds `HeaderBanner` to all pages.

In July the banner ran site-wide, so we have per-page numbers instead of a guess. **38% of that sale's banner clicks came from pages that have no banner today.** Window is Jul 20–22 (pulled on the 21st by `End sale #332`); PostHog project 253422.

| clicks | CTR | pageviews | page | today |
|---|---|---|---|---|
| 178 | 19.4/1k | 9,184 | `/` | has banner |
| 36 | 6.1/1k | 5,857 | `/shop/comma-four` | destination |
| **33** | **10.9/1k** | 3,033 | **`/openpilot`** | **none** |
| **23** | **3.4/1k** | 6,854 | **`/vehicles`** | **none** |
| 10 | 3.0/1k | 3,296 | `/shop` | has banner |
| 5 | 34.5/1k | 145 | `/shop/comma-four-trade-in` | destination |
| 4 | 6.0/1k | 667 | `/support` | none |
| 4 | 9.8/1k | 408 | `/connect` | none |
| 2 | 24.4/1k | 82 | `/shop/comma-3x-out-of-warranty-repair` | none |
| 2 | 5.6/1k | 360 | `/shop/car-harness` | none |
| 1 each | 4.5–23.8/1k | 42–222 | `/shop/panda`, `/panda-jungle`, `/harness-box`, `/comma-device-screen` | none |
| 0 | — | 976 | `/jobs` | none — deliberately excluded |

`/openpilot` has 3.2× the CTR of `/vehicles` on less than half the traffic; `/vehicles` earns its place on volume (7,431 pv/wk today, 3.6× `/openpilot`). Projected ~48–68 added clicks/wk against ~708/wk today, roughly **+7–10% banner volume**.

**`/setup` has no supporting data.** It drew 1 click on 21 pageviews of `www.comma.ai/setup`, while the canonical `comma.ai/setup` had ~1,060 pageviews and zero clicks. Projected ~0. Included on judgment, not evidence — essentially all the gain is `/openpilot` and `/vehicles`. `/jobs` was excluded on the same evidence the other way: 976 pageviews, zero clicks.

Banner clickers reach Checkout at 28.3% vs 3.54% (Labor Day, n=166) and 11.9% vs 1.56% (July, n=302). **Association, not causation** — clicking a sale banner is itself an intent signal, and nothing here shows the clicks are incremental rather than people who'd have reached the product page anyway.

`/shop/comma-four` is at 10,744 pv/wk now; if this works it should lift within days.